### PR TITLE
Implement lag metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Prometheus Kafka Consumer Group Exporter
 ====
-This Prometheus exporter consumes the `__consumer_offsets` topic of a Kafka cluser and exports the results as Prometheus gauge metrics. i.e. it shows the position of Kafka consumer groups.
+This Prometheus exporter consumes the `__consumer_offsets` topic of a Kafka cluser and exports the results as Prometheus gauge metrics. i.e. it shows the position of Kafka consumer groups, including their lag.
 
-The high-water marks of the partitions of each topic are also exported.
+The high-water and low-water marks of the partitions of each topic are also exported.
 
 # Installation
 The exporter requires Python 3 and Pip 3 to be installed.

--- a/README.md
+++ b/README.md
@@ -30,11 +30,23 @@ Four main metrics are exported:
 ### `kafka_consumer_group_offset{group, topic, partition}`
 The latest committed offset of a consumer group in a given partition of a topic, as read from `__consumer_offsets`. Useful for calculating the consumption rate and lag of a consumer group.
 
+### `kafka_consumer_group_lag{group, topic, partition}`
+The lag of a consumer group behind the head of a given partition of a topic - the difference between `kafka_topic_highwater` and `kafka_consumer_group_offset`. Useful for checking if a consumer group is keeping up with a topic.
+
+### `kafka_consumer_group_lead{group, topic, partition}`
+The lead of a consumer group ahead of the tail of a given partition of a topic - the difference between `kafka_consumer_group_offset` and `kafka_topic_lowwater`. Useful for checking if a consumer group is at risk of missing messages due to the cleaner.
+
 ### `kafka_consumer_group_commits{group, topic, partition}`
 The number of commit messages read from `__consumer_offsets` by the exporter from a consumer group for a given partition of a topic. Useful for calculating the commit rate of a consumer group (i.e. are the consumers working).
 
 ### `kafka_consumer_group_exporter_offset{partition}`
 The offset of the exporter's consumer in each partition of the `__consumer_offset` topic. Useful for calculating the lag of the exporter.
+
+### `kafka_consumer_group_exporter_lag{partition}`
+The lag of the exporter's consumer behind the head of each partition of the `__consumer_offset` topic. Useful for checking if the exporter is keeping up with `__consumer_offset`.
+
+### `kafka_consumer_group_exporter_lead{partition}`
+The lead of the exporter's consumer ahead of the tail of each partition of the `__consumer_offset` topic. Useful for checking if the exporter is at risk of missing messages due to the cleaner.
 
 ### `kafka_topic_highwater{topic, partition}`
 The offset of the head of a given partition of a topic, as reported by the lead broker for the partition. Useful for calculating the production rate of the producers for a topic, and the lag of a consumer group (or the exporter itself).
@@ -43,7 +55,7 @@ The offset of the head of a given partition of a topic, as reported by the lead 
 The offset of the tail of a given partition of a topic, as reported by the lead broker for the partition. Useful for calculating the lead of a consumer group (or the exporter itself) - i.e. how far ahead of the cleaner the consumer group is.
 
 ## Lag
-While a lag metric isn't exported, it can be calculated using other metrics:
+Lag metrics are exported for convenience, but they can also be calculated using other metrics if desired:
 ```
 # Lag for a consumer group:
 kafka_topic_highwater - on (topic, partition) kafka_consumer_group_offset{group="some-consumer-group"}

--- a/prometheus_kafka_consumer_group_exporter/__init__.py
+++ b/prometheus_kafka_consumer_group_exporter/__init__.py
@@ -489,6 +489,7 @@ def main():
                             nodes[leader][topic] = []
                         nodes[leader][topic].append(partition)
 
+                global node_highwaters
                 # Build a new highwaters dict with only the nodes that
                 # are leaders of at least one topic - i.e. the ones
                 # we will be sending requests to.
@@ -501,7 +502,6 @@ def main():
                 for node in nodes.keys():
                     new_node_highwaters[node] = node_highwaters.get(node, {})
 
-                global node_highwaters
                 node_highwaters = new_node_highwaters
 
                 for node, topic_map in nodes.items():
@@ -536,6 +536,7 @@ def main():
                             nodes[leader][topic] = []
                         nodes[leader][topic].append(partition)
 
+                global node_lowwaters
                 # Build a new node_lowwaters dict with only the nodes that
                 # are leaders of at least one topic - i.e. the ones
                 # we will be sending requests to.
@@ -548,7 +549,6 @@ def main():
                 for node in nodes.keys():
                     new_node_lowwaters[node] = node_lowwaters.get(node, {})
 
-                global node_lowwaters
                 node_lowwaters = new_node_lowwaters
 
                 for node, topic_map in nodes.items():

--- a/prometheus_kafka_consumer_group_exporter/__init__.py
+++ b/prometheus_kafka_consumer_group_exporter/__init__.py
@@ -413,6 +413,7 @@ def main():
                         group = key[1]
                         topic = key[2]
                         partition = key[3]
+                        offset = value[1]
 
                         update_gauge(
                             metric_name=METRIC_PREFIX + 'offset',
@@ -421,7 +422,7 @@ def main():
                                 'topic': topic,
                                 'partition': partition
                             },
-                            value=value[1],
+                            value=offset,
                             doc='The current offset of a consumer group in a partition of a topic.'
                         )
 
@@ -434,7 +435,7 @@ def main():
                                     'topic': topic,
                                     'partition': partition
                                 },
-                                value=highwater,
+                                value=highwater - offset,
                                 doc='How far a consumer group\'s current offset is behind the head of a partition of a topic'
                             )
 
@@ -447,7 +448,7 @@ def main():
                                     'topic': topic,
                                     'partition': partition
                                 },
-                                value=lowwater,
+                                value=offset - lowwater,
                                 doc='How far a consumer group\'s current offset is ahead of the tail of a partition of a topic'
                             )
 


### PR DESCRIPTION
Implements https://github.com/braedon/prometheus-kafka-consumer-group-exporter/issues/8

Note: This PR includes a fairly major refactor of how metrics are calculated to make it easier to implement the lag metric.