### PR TITLE
Fix -b default value overriding consumer config

### DIFF
--- a/prometheus_kafka_consumer_group_exporter/__init__.py
+++ b/prometheus_kafka_consumer_group_exporter/__init__.py
@@ -43,7 +43,7 @@ def main():
     parser = argparse.ArgumentParser(
         description='Export Kafka consumer offsets to Prometheus.')
     parser.add_argument(
-        '-b', '--bootstrap-brokers', default='localhost',
+        '-b', '--bootstrap-brokers',
         help='Addresses of brokers in a Kafka cluster to talk to.' +
         ' Brokers should be separated by commas e.g. broker1,broker2.' +
         ' Ports can be provided if non-standard (9092) e.g. brokers1:9999.' +
@@ -107,7 +107,9 @@ def main():
             consumer_config.update(converted_config)
 
     if args.bootstrap_brokers:
-        consumer_config['bootstrap_servers'] = args.bootstrap_brokers.split(',')
+        consumer_config['bootstrap_servers'] = args.bootstrap_brokers
+
+    consumer_config['bootstrap_servers'] = consumer_config['bootstrap_servers'].split(',')
 
     if args.from_start:
         consumer_config['auto_offset_reset'] = 'earliest'


### PR DESCRIPTION
The default value of the command line argument `-b` (`--bootstrap-brokers`) overrides the value given in the consumer config (`consumer.properties`) file as the code can't tell if the value is the default or it was provided. This problem manifests when `-b` is not passed as argument and `consumer.properties` contains `bootstrap.server` with a value other than `localhost`. If not overrided by argument, the value in the `consumer.properties` file should be used.

The fix involves dropping the default value in the arguments definition to allow the code to later overwrite the config if the argument was really present. The default value for the bootstrap brokers is set in the initialization of the `consumer_config` dict maintaining the behavior stated in the docs.