### PR TITLE
Add metric to track timestamps of commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Run with the `-h` flag to see details on all the available arguments.
 Prometheus metrics can then be scraped from the `/metrics` path, e.g. http://localhost:9208/metrics. Metrics are currently actually exposed on all paths, but this may change in the future and `/metrics` is the standard path for Prometheus metric endpoints.
 
 # Metrics
-Nine main metrics are exported:
+Ten main metrics are exported:
 
 ### `kafka_consumer_group_offset{group, topic, partition}`
 The latest committed offset of a consumer group in a given partition of a topic, as read from `__consumer_offsets`. Useful for calculating the consumption rate and lag of a consumer group.
@@ -38,6 +38,9 @@ The lead of a consumer group ahead of the tail of a given partition of a topic -
 
 ### `kafka_consumer_group_commits{group, topic, partition}`
 The number of commit messages read from `__consumer_offsets` by the exporter from a consumer group for a given partition of a topic. Useful for calculating the commit rate of a consumer group (i.e. are the consumers working).
+
+### `kafka_consumer_group_timestamp_seconds{group, topic, partition}`
+The timestamp (in seconds) of the latest commits from a consumer group for a given partition of a topic. Useful to determine how long a consumer has been inactive.
 
 ### `kafka_consumer_group_exporter_offset{partition}`
 The offset of the exporter's consumer in each partition of the `__consumer_offset` topic. Useful for calculating the lag of the exporter.

--- a/prometheus_kafka_consumer_group_exporter/collectors.py
+++ b/prometheus_kafka_consumer_group_exporter/collectors.py
@@ -7,6 +7,7 @@ METRIC_PREFIX = 'kafka_consumer_group_'
 # Globals
 offsets = {}  # group->topic->partition->offset
 commits = {}  # group->topic->partition->commits
+timestamps = {}  # group->topic->partition->timestamp
 exporter_offsets = {}  # partition->offset
 
 
@@ -26,6 +27,15 @@ def get_commits():
 def set_commits(new_commits):
     global commits
     commits = new_commits
+
+
+def get_timestamps():
+    return timestamps
+
+
+def set_timestamps(new_timestamps):
+    global timestamps
+    timestamps = new_timestamps
 
 
 def get_exporter_offsets():
@@ -174,6 +184,20 @@ class ConsumerCommitsCollector(object):
             for partition, commit_count in partitions.items()
         ]
         yield from counter_generator(metrics)
+
+
+class ConsumerTimestampCollector(object):
+
+    def collect(self):
+        metrics = [
+            (METRIC_PREFIX + 'timestamp_seconds', 'The latest commit timestamp from a consumer group for a partition of a topic.',
+             ('group', 'topic', 'partition'), (group, topic, partition),
+             timestamp)
+            for group, topics in timestamps.items()
+            for topic, partitions in topics.items()
+            for partition, timestamp in partitions.items()
+        ]
+        yield from gauge_generator(metrics)
 
 
 class ExporterOffsetCollector(object):


### PR DESCRIPTION
This PR introduces a new metric `kafka_consumer_group_timestamp_seconds`, which is a gauge that contains the timestamp (scaled to seconds) of the latest commit for a group/topic/partition.

I'd like to add this because as is, we have no reliable way to determine when the latest commit is, which we would find useful. For active consumers, we can see when the `kafka_consumer_group_commits` metric increases, but for old consumers who do not have fresh commits, there is no such mechanism. 

This can be useful to limit queries to show data that's been updated within a certain window, or to exclude alerts for old consumers that have been deprecated.