### PR TITLE
Catch exceptions if keys/values fail to parse. Resolves #22.

### DIFF
--- a/prometheus_kafka_consumer_group_exporter/__init__.py
+++ b/prometheus_kafka_consumer_group_exporter/__init__.py
@@ -155,23 +155,23 @@ def main():
                     key = parse_key(message.key)
                     if key:
                         value = parse_value(message.value)
+                        if value:
+                            group = key[1]
+                            topic = key[2]
+                            partition = key[3]
+                            offset = value[1]
 
-                        group = key[1]
-                        topic = key[2]
-                        partition = key[3]
-                        offset = value[1]
+                            offsets = ensure_dict_key(offsets, group, {})
+                            offsets[group] = ensure_dict_key(offsets[group], topic, {})
+                            offsets[group][topic] = ensure_dict_key(offsets[group][topic], partition, offset)
+                            offsets[group][topic][partition] = offset
+                            collectors.set_offsets(offsets)
 
-                        offsets = ensure_dict_key(offsets, group, {})
-                        offsets[group] = ensure_dict_key(offsets[group], topic, {})
-                        offsets[group][topic] = ensure_dict_key(offsets[group][topic], partition, offset)
-                        offsets[group][topic][partition] = offset
-                        collectors.set_offsets(offsets)
-
-                        commits = ensure_dict_key(commits, group, {})
-                        commits[group] = ensure_dict_key(commits[group], topic, {})
-                        commits[group][topic] = ensure_dict_key(commits[group][topic], partition, 0)
-                        commits[group][topic][partition] += 1
-                        collectors.set_commits(commits)
+                            commits = ensure_dict_key(commits, group, {})
+                            commits[group] = ensure_dict_key(commits[group], topic, {})
+                            commits[group][topic] = ensure_dict_key(commits[group][topic], partition, 0)
+                            commits[group][topic][partition] += 1
+                            collectors.set_commits(commits)
 
                 # Check if we need to run any scheduled jobs
                 # each message.

--- a/prometheus_kafka_consumer_group_exporter/parsing.py
+++ b/prometheus_kafka_consumer_group_exporter/parsing.py
@@ -1,4 +1,4 @@
-from struct import unpack_from
+from struct import unpack_from, error as struct_error
 
 
 def read_short(bytes):
@@ -27,24 +27,30 @@ def read_string(bytes):
 
 
 def parse_key(bytes):
-    (version, remaining_key) = read_short(bytes)
-    if version == 1 or version == 0:
-        (group, remaining_key) = read_string(remaining_key)
-        (topic, remaining_key) = read_string(remaining_key)
-        (partition, remaining_key) = read_int(remaining_key)
-        return (version, group, topic, partition)
+    try:
+        (version, remaining_key) = read_short(bytes)
+        if version == 1 or version == 0:
+            (group, remaining_key) = read_string(remaining_key)
+            (topic, remaining_key) = read_string(remaining_key)
+            (partition, remaining_key) = read_int(remaining_key)
+            return (version, group, topic, partition)
+    except struct_error:
+        pass
 
 
 def parse_value(bytes):
-    (version, remaining_key) = read_short(bytes)
-    if version == 0:
-        (offset, remaining_key) = read_long_long(remaining_key)
-        (metadata, remaining_key) = read_string(remaining_key)
-        (timestamp, remaining_key) = read_long_long(remaining_key)
-        return (version, offset, metadata, timestamp)
-    elif version == 1:
-        (offset, remaining_key) = read_long_long(remaining_key)
-        (metadata, remaining_key) = read_string(remaining_key)
-        (commit_timestamp, remaining_key) = read_long_long(remaining_key)
-        (expire_timestamp, remaining_key) = read_long_long(remaining_key)
-        return (version, offset, metadata, commit_timestamp, expire_timestamp)
+    try:
+        (version, remaining_key) = read_short(bytes)
+        if version == 0:
+            (offset, remaining_key) = read_long_long(remaining_key)
+            (metadata, remaining_key) = read_string(remaining_key)
+            (timestamp, remaining_key) = read_long_long(remaining_key)
+            return (version, offset, metadata, timestamp)
+        elif version == 1:
+            (offset, remaining_key) = read_long_long(remaining_key)
+            (metadata, remaining_key) = read_string(remaining_key)
+            (commit_timestamp, remaining_key) = read_long_long(remaining_key)
+            (expire_timestamp, remaining_key) = read_long_long(remaining_key)
+            return (version, offset, metadata, commit_timestamp, expire_timestamp)
+    except struct_error:
+        pass


### PR DESCRIPTION
There are scenarios where the data in __consumer_offsets may not match the expected values. In such cases, this exporter will completely fail and will never be able to progress on partition with the problematic message.

This PR catches the exception, then discards the message and moves on.