### PR TITLE
Upgrade Prometheus client to fix memory leak with Python 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     install_requires=[
         'kafka-python >= 1.3',
         'jog',
-        'prometheus-client',
+        'prometheus-client >= 0.6.0',
         'javaproperties'
     ],
     entry_points={


### PR DESCRIPTION
https://github.com/prometheus/client_python/issues/340

Fixes https://github.com/braedon/prometheus-kafka-consumer-group-exporter/issues/18