### PR TITLE
Prevent lag metric from going below 0

### DIFF
--- a/prometheus_kafka_consumer_group_exporter/collectors.py
+++ b/prometheus_kafka_consumer_group_exporter/collectors.py
@@ -137,7 +137,7 @@ class ConsumerLagCollector(object):
         metrics = [
             (METRIC_PREFIX + 'lag', 'How far a consumer group\'s current offset is behind the head of a partition of a topic.',
              ('group', 'topic', 'partition'), (group, topic, partition),
-             highwaters[topic][partition] - offset)
+             max(highwaters[topic][partition] - offset, 0))
             for group, topics in offsets.items()
             for topic, partitions in topics.items()
             for partition, offset in partitions.items()
@@ -196,7 +196,7 @@ class ExporterLagCollector(object):
         metrics = [
             (METRIC_PREFIX + 'exporter_lag', 'How far the exporter consumer is behind the head of a partition of the __consumer_offsets topic.',
              ('partition',), (partition,),
-             highwaters[topic][partition] - offset)
+             max(highwaters[topic][partition] - offset, 0))
             for partition, offset in exporter_offsets.items()
             if topic in highwaters and partition in highwaters[topic]
         ]


### PR DESCRIPTION
Lag can often appear to be negative due to the highwaters being less up to
date than the consumer's offset. A negative lag doesn't make sense, and
isn't actually correct, so nicer to report 0 instead.

Fixes https://github.com/braedon/prometheus-kafka-consumer-group-exporter/issues/21