### PR TITLE
16 add timestamp metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ The lead of a consumer group ahead of the tail of a given partition of a topic -
 ### `kafka_consumer_group_commits{group, topic, partition}`
 The number of commit messages read from `__consumer_offsets` by the exporter from a consumer group for a given partition of a topic. Useful for calculating the commit rate of a consumer group (i.e. are the consumers working).
 
-### `kafka_consumer_group_timestamp_seconds{group, topic, partition}`
-The timestamp (in seconds) of the latest commits from a consumer group for a given partition of a topic. Useful to determine how long a consumer has been inactive.
+### `kafka_consumer_group_commit_timestamp{group, topic, partition}`
+The timestamp (in seconds since January 1, 1970 UTC) of the latest commit from a consumer group for a given partition of a topic. Useful to determine how long a consumer has been inactive.
 
 ### `kafka_consumer_group_exporter_offset{partition}`
 The offset of the exporter's consumer in each partition of the `__consumer_offset` topic. Useful for calculating the lag of the exporter.

--- a/prometheus_kafka_consumer_group_exporter/__init__.py
+++ b/prometheus_kafka_consumer_group_exporter/__init__.py
@@ -134,7 +134,7 @@ def main():
     REGISTRY.register(collectors.ConsumerLagCollector())
     REGISTRY.register(collectors.ConsumerLeadCollector())
     REGISTRY.register(collectors.ConsumerCommitsCollector())
-    REGISTRY.register(collectors.ConsumerTimestampCollector())
+    REGISTRY.register(collectors.ConsumerCommitTimestampCollector())
     REGISTRY.register(collectors.ExporterOffsetCollector())
     REGISTRY.register(collectors.ExporterLagCollector())
     REGISTRY.register(collectors.ExporterLeadCollector())
@@ -146,7 +146,7 @@ def main():
             for message in consumer:
                 offsets = collectors.get_offsets()
                 commits = collectors.get_commits()
-                timestamps = collectors.get_timestamps()
+                commit_timestamps = collectors.get_commit_timestamps()
                 exporter_offsets = collectors.get_exporter_offsets()
 
                 exporter_partition = message.partition
@@ -164,7 +164,7 @@ def main():
                             topic = key[2]
                             partition = key[3]
                             offset = value[1]
-                            timestamp = message.timestamp / 1000
+                            commit_timestamp = message.timestamp / 1000
 
                             offsets = ensure_dict_key(offsets, group, {})
                             offsets[group] = ensure_dict_key(offsets[group], topic, {})
@@ -178,11 +178,11 @@ def main():
                             commits[group][topic][partition] += 1
                             collectors.set_commits(commits)
 
-                            timestamps = ensure_dict_key(timestamps, group, {})
-                            timestamps[group] = ensure_dict_key(timestamps[group], topic, {})
-                            timestamps[group][topic] = ensure_dict_key(timestamps[group][topic], partition, 0)
-                            timestamps[group][topic][partition] = timestamp
-                            collectors.set_timestamps(timestamps)
+                            commit_timestamps = ensure_dict_key(commit_timestamps, group, {})
+                            commit_timestamps[group] = ensure_dict_key(commit_timestamps[group], topic, {})
+                            commit_timestamps[group][topic] = ensure_dict_key(commit_timestamps[group][topic], partition, 0)
+                            commit_timestamps[group][topic][partition] = commit_timestamp
+                            collectors.set_commit_timestamps(commit_timestamps)
 
                 # Check if we need to run any scheduled jobs
                 # each message.

--- a/prometheus_kafka_consumer_group_exporter/__init__.py
+++ b/prometheus_kafka_consumer_group_exporter/__init__.py
@@ -164,7 +164,7 @@ def main():
                             topic = key[2]
                             partition = key[3]
                             offset = value[1]
-                            commit_timestamp = message.timestamp / 1000
+                            commit_timestamp = value[3] / 1000
 
                             offsets = ensure_dict_key(offsets, group, {})
                             offsets[group] = ensure_dict_key(offsets[group], topic, {})

--- a/prometheus_kafka_consumer_group_exporter/collectors.py
+++ b/prometheus_kafka_consumer_group_exporter/collectors.py
@@ -7,7 +7,7 @@ METRIC_PREFIX = 'kafka_consumer_group_'
 # Globals
 offsets = {}  # group->topic->partition->offset
 commits = {}  # group->topic->partition->commits
-timestamps = {}  # group->topic->partition->timestamp
+commit_timestamps = {}  # group->topic->partition->commit_timestamp
 exporter_offsets = {}  # partition->offset
 
 
@@ -29,13 +29,13 @@ def set_commits(new_commits):
     commits = new_commits
 
 
-def get_timestamps():
-    return timestamps
+def get_commit_timestamps():
+    return commit_timestamps
 
 
-def set_timestamps(new_timestamps):
-    global timestamps
-    timestamps = new_timestamps
+def set_commit_timestamps(new_commit_timestamps):
+    global commit_timestamps
+    commit_timestamps = new_commit_timestamps
 
 
 def get_exporter_offsets():
@@ -186,16 +186,16 @@ class ConsumerCommitsCollector(object):
         yield from counter_generator(metrics)
 
 
-class ConsumerTimestampCollector(object):
+class ConsumerCommitTimestampCollector(object):
 
     def collect(self):
         metrics = [
-            (METRIC_PREFIX + 'timestamp_seconds', 'The latest commit timestamp from a consumer group for a partition of a topic.',
+            (METRIC_PREFIX + 'commit_timestamp', 'The timestamp of the latest commit from a consumer group for a partition of a topic.',
              ('group', 'topic', 'partition'), (group, topic, partition),
-             timestamp)
-            for group, topics in timestamps.items()
+             commit_timestamp)
+            for group, topics in commit_timestamps.items()
             for topic, partitions in topics.items()
-            for partition, timestamp in partitions.items()
+            for partition, commit_timestamp in partitions.items()
         ]
         yield from gauge_generator(metrics)
 


### PR DESCRIPTION
Merges https://github.com/braedon/prometheus-kafka-consumer-group-exporter/pull/16, and makes some adjustments - mainly renaming metric from `timestamp_seconds` to `commit_timestamp` for clarity.