### PR TITLE
Kafka python 1.4.4

### DIFF
--- a/prometheus_kafka_consumer_group_exporter/__init__.py
+++ b/prometheus_kafka_consumer_group_exporter/__init__.py
@@ -210,29 +210,6 @@ def main():
                                     if partition in commit_timestamps[group][topic]:
                                         del commit_timestamps[group][topic][partition]
 
-                elif message.key and not message.value:
-                    # The group has been removed, so we should not report metrics
-                    key_dict = parse_key(message.key)
-                    if key_dict is not None and key_dict['version'] in (0, 1):
-                        group = key_dict['group']
-                        topic = key_dict['topic']
-                        partition = key_dict['partition']
-
-                        if group in offsets:
-                            if topic in offsets[group]:
-                                if partition in offsets[group][topic]:
-                                    del offsets[group][topic][partition]
-
-                        if group in commits:
-                            if topic in commits[group]:
-                                if partition in commits[group][topic]:
-                                    del commits[group][topic][partition]
-                        
-                        if group in commit_timestamps:
-                            if topic in commit_timestamps[group]:
-                                if partition in commit_timestamps[group][topic]:
-                                    del commit_timestamps[group][topic][partition]
-
                 # Check if we need to run any scheduled jobs
                 # each message.
                 scheduled_jobs = scheduler.run_scheduled_jobs(scheduled_jobs)

--- a/prometheus_kafka_consumer_group_exporter/parsing.py
+++ b/prometheus_kafka_consumer_group_exporter/parsing.py
@@ -44,7 +44,7 @@ def parse_key(bytes):
             key_dict['group'], remaining_key = read_string(remaining_key)
 
         else:
-            logging.error('Can\'t parse __consumer_offsets topic message key with'
+            logging.warning('Can\'t parse __consumer_offsets topic message key with'
                           ' unsupported version %(version)s.',
                           {'version': version})
             return None
@@ -52,9 +52,10 @@ def parse_key(bytes):
         return key_dict
 
     except struct_error:
-        logging.exception('Failed to parse key from __consumer_offsets topic message.'
+        logging.warning('Failed to parse key from __consumer_offsets topic message.'
                           ' Key: %(key_bytes)s',
-                          {'key_bytes': bytes})
+                          {'key_bytes': bytes},
+                          exc_info=True)
 
 
 def parse_value(bytes):
@@ -85,7 +86,7 @@ def parse_value(bytes):
             value_dict['commit_timestamp'], remaining_key = read_long_long(remaining_key)
 
         else:
-            logging.error('Can\'t parse __consumer_offsets topic message value with'
+            logging.warning('Can\'t parse __consumer_offsets topic message value with'
                           ' unsupported version %(version)s.',
                           {'version': version})
             return None
@@ -93,6 +94,7 @@ def parse_value(bytes):
         return value_dict
 
     except struct_error as e:
-        logging.exception('Failed to parse value from __consumer_offsets topic message.'
+        logging.warning('Failed to parse value from __consumer_offsets topic message.'
                           ' Value: %(value_bytes)s',
-                          {'value_bytes': bytes})
+                          {'value_bytes': bytes},
+                          exc_info=True)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     keywords='monitoring prometheus exporter kafka consumer group',
     packages=find_packages(),
     install_requires=[
-        'kafka-python >= 1.3',
+        'kafka-python == 1.4.4',
         'jog',
         'prometheus-client >= 0.6.0',
         'javaproperties'


### PR DESCRIPTION
This PR makes a few changes. 

Primarily, it updates the dependency on kafka-python to use 1.4.4 in order to fix #30. 

I removed some unreachable code, which was introduced when refactoring the logic to remove data for deleted consumer groups. 

Logs from parsing failures are changed from ERROR to WARNING, which seems appropriate since these failures are not the fault of the exporter. It just encountered bad data. We should be able to let real errors through and hide these messages by changing the log level.