### PR TITLE
Support for boolean values in consumer_config

### DIFF
--- a/prometheus_kafka_consumer_group_exporter/__init__.py
+++ b/prometheus_kafka_consumer_group_exporter/__init__.py
@@ -103,8 +103,10 @@ def main():
     for filename in args.consumer_config:
         with open(filename) as f:
             raw_config = javaproperties.load(f)
-            converted_config = {k.replace('.', '_'): v for k, v in raw_config.items()}
-            consumer_config.update(converted_config)
+            for k, v in raw_config.items():
+                if v in ['true', 'false']:
+                    v = True if v == 'true' else False
+                consumer_config[k.replace('.', '_')] = v
 
     if args.bootstrap_brokers:
         consumer_config['bootstrap_servers'] = args.bootstrap_brokers


### PR DESCRIPTION
Recently, I had to add a parameter(`ssl.check.hosthostname`) with boolean value to the `consumer.properties` and realized that I can't add boolean value without editing the code. So I added a support for it. :)

- Sample consumer.properties
```
security.protocol=SSL
ssl.certfile=/path/to/my_cert.pem
ssl.keyfile=/path/to/my_key.pem
ssl.check.hostname=false
```
