### PR TITLE
network: listen on every IP

### DIFF
--- a/prometheus_kafka_consumer_group_exporter/__init__.py
+++ b/prometheus_kafka_consumer_group_exporter/__init__.py
@@ -143,7 +143,7 @@ def main():
     low_water_interval = args.low_water_interval
 
     logging.info('Starting server...')
-    start_http_server(port)
+    start_http_server(port, '::')
     logging.info('Server started on port %s', port)
 
     REGISTRY.register(collectors.HighwaterCollector())


### PR DESCRIPTION
The `::` listen address means that it will listen on all IPv4 and IPv6 addresses.

Solves #45.